### PR TITLE
Ran Acrolinx and made some edits.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,7 +63,7 @@ Create the JAX-RS resource class in the `src/main/java/io/openliberty/guides/res
 include::finish/src/main/java/io/openliberty/guides/rest/PropertiesResource.java[tags=**;!comment]
 ----
 
-This resource class has quite a bit of code in it, so break it down into manageable chunks.
+This resource class has quite a bit of code in it, so let's break it down into manageable chunks.
 
 The `@Path` annotation on the class indicates that this resource responds to the `properties` path in the JAX-RS application. The `@ApplicationPath` annotation in the application class together with the `@Path` annotation in this class indicates that the resource is available at the `System/properties` path.
 [source,java,role="no_copy"]

--- a/README.adoc
+++ b/README.adoc
@@ -51,11 +51,11 @@ Create the JAX-RS application class in the `src/main/java/io/openliberty/guides/
 ----
 include::finish/src/main/java/io/openliberty/guides/rest/SystemApplication.java[tags=**;!comment]
 ----
-The `SystemApplication` class extends the `Application` class which, by default, associates all JAX-RS resource classes in the WAR file with this JAX-RS application. The `@ApplicationPath` annotation has a value that indicates the path within the WAR that the JAX-RS application accepts requests from.
+The `SystemApplication` class extends the `Application` class, which, by default, associates all JAX-RS resource classes in the WAR file with this JAX-RS application. The `@ApplicationPath` annotation has a value that indicates the path within the WAR that the JAX-RS application accepts requests from.
 
 == Creating the JAX-RS resource
 
-In JAX-RS, a single class should represent a single resource, or a group of resources of the same type. In this application a resource might be a system property, or a set of system properties. It is easy to have a single class handle multiple different resources, but keeping a clean separation between types of resources helps with maintainability in the long run.
+In JAX-RS, a single class should represent a single resource, or a group of resources of the same type. In this application, a resource might be a system property, or a set of system properties. It is easy to have a single class handle multiple different resources, but keeping a clean separation between types of resources helps with maintainability in the long run.
 
 Create the JAX-RS resource class in the `src/main/java/io/openliberty/guides/rest/PropertiesResource.java` file:
 [source,java]
@@ -63,9 +63,9 @@ Create the JAX-RS resource class in the `src/main/java/io/openliberty/guides/res
 include::finish/src/main/java/io/openliberty/guides/rest/PropertiesResource.java[tags=**;!comment]
 ----
 
-This resource class has quite a bit of code in it, so let's break it down into manageable chunks.
+This resource class has quite a bit of code in it, so break it down into manageable chunks.
 
-The `@Path` annotation on the class indicates that this resource responds to the `properties` path in the JAX-RS application. The `@ApplicationPath` annotation in the application class together with the `@Path` annotation in this class indicates that the resource is be available at `System/properties` path.
+The `@Path` annotation on the class indicates that this resource responds to the `properties` path in the JAX-RS application. The `@ApplicationPath` annotation in the application class together with the `@Path` annotation in this class indicates that the resource is available at the `System/properties` path.
 [source,java,role="no_copy"]
 ----
 include::finish/src/main/java/io/openliberty/guides/rest/PropertiesResource.java[tags=class]
@@ -78,18 +78,18 @@ JAX-RS maps the HTTP methods on the URL to the methods on the class. The method 
 include::finish/src/main/java/io/openliberty/guides/rest/PropertiesResource.java[tags=getProperties]
 ----
 
-The `@GET` annotation on the method indicates that this method it to be called for the HTTP `GET` method. The `@Produces` annotation indicates the format of the content that will be returned, the value of the `@Produces` annotation will be specified in the HTTP `Content-Type` response header. For this application a JSON structure is to be returned. The desired `Content-Type` for a JSON response is `application/json`, using `MediaType.APPLICATION_JSON` instead of the `String` literal is better because in the event of a spelling error a compile failure will occur.
+The `@GET` annotation on the method indicates that this method it to be called for the HTTP `GET` method. The `@Produces` annotation indicates the format of the content that will be returned, the value of the `@Produces` annotation will be specified in the HTTP `Content-Type` response header. For this application, a JSON structure is to be returned. The desired `Content-Type` for a JSON response is `application/json` with `MediaType.APPLICATION_JSON` instead of the `String` code. Literal code is better because in the event of a spelling error, a compile failure occurs.
 
 JAX-RS supports a number of ways to marshal JSON. The JAX-RS 2.0 specification mandates JSON-Processing (JSON-P) and JAX-B. Most JAX-RS implementations also support a Java POJO-to-JSON conversion, which allows the `Properties` object to be returned instead. Although this conversion would allow for a simpler implementation, it limits code portability as POJO-to-JSON conversion is non-standard. This gap in the specification will be fixed in Java EE 8 with the inclusion of JSON-B.
 
-The method body does the following:
+The method body does the following actions:
 
 . Creates a `JsonObjectBuilder` object using the `Json` class. The `JsonObjectBuilder` is then used to populate a `JsonObject` with values.
-. Call the `getProperties` method on the `System` class to get a `Properties` object that contains all the system properties.
-. Call the `entrySet` method on the `Properties` object to get a `Set` of all the entries.
+. Calls the `getProperties` method on the `System` class to get a `Properties` object that contains all the system properties.
+. Calls the `entrySet` method on the `Properties` object to get a `Set` of all the entries.
 . Convert the `Set` to a `Stream` (new in Java SE 8) by calling the `stream` method. Streams make working through all the entries in a list very simple.
-. Call the `forEach` method on the `Stream` passing in a function that will be invoked for each entry in the `Stream`. The function passed in will call the `add` method on the `JsonObjectBuilder` for every entry in the stream. The key and value for the `JsonObject` will be obtained by calling the `getKey` and `getValue` methods on the `Map.Entry` objects in the stream.
-. Return the a `JsonObject` by calling the `build` method on the `JsonObjectBuilder`.
+. Calls the `forEach` method on the `Stream` passing in a function that will be invoked for each entry in the `Stream`. The function passed in will call the `add` method on the `JsonObjectBuilder` for every entry in the stream. The key and value for the `JsonObject` will be obtained by calling the `getKey` and `getValue` methods on the `Map.Entry` objects in the stream.
+. Returns the `JsonObject` by calling the `build` method on the `JsonObjectBuilder`.
 
 include::{common-includes}/mvnbuild.adoc[]
 
@@ -97,7 +97,7 @@ include::{common-includes}/mvnbuild.adoc[]
 
 You could test this service manually by starting a server and pointing a web browser at the `\http://localhost:9080/LibertyProject/System/properties` URL. Automated tests are a much better approach because they will trigger a failure if a change introduces a bug. JUnit and the JAX-RS Client API provide a very simple environment to test the application.
 
-You can write tests for the individual units of code outside of a running application server, or they can be written to call the application server directly. In this example you will create a test that does the latter.
+You can write tests for the individual units of code outside of a running application server, or they can be written to call the application server directly. In this example, you will create a test that does the latter.
 
 Create the test class in the `src/test/java/it/io/openliberty/guides/rest/EndpointTest.java` file:
 
@@ -129,14 +129,14 @@ Getting the values to create a representation of the URL is simple. The test cla
 include::finish/src/test/java/it/io/openliberty/guides/rest/EndpointTest.java[tags=systemProperties]
 ----
 
-The JAX-RS client can be used to make the REST call and convert the payload to and from a JSON-P representation. To get the JAX-RS client to do the conversion the client needs to have the `JsrJsonpProvider` class registered with it by calling the `register` method and providing the `Class` object for the `JsrJsonpProvider` class:
+The JAX-RS client can be used to make the REST call and convert the payload to and from a JSON-P representation. To get the JAX-RS client to do the conversion, the client needs to have the `JsrJsonpProvider` class registered with it by calling the `register` method and providing the `Class` object for the `JsrJsonpProvider` class:
 
 [source,java,indent=0,role="no_copy"]
 ----
 include::finish/src/test/java/it/io/openliberty/guides/rest/EndpointTest.java[tags=clientSetup]
 ----
 
-To call the JAX-RS service using the JAX-RS client you first create a `WebTarget` object by calling the `target` method providing the URL. To cause the HTTP request to occur first the `request` method on `WebTarget` and then the `get` method on the returned object need to be called. The `get` method call is a synchronous call that blocks until a response is received. This call returns a `Response` object which can be interrogated to determine whether the request was successful:
+To call the JAX-RS service using the JAX-RS client, you first create a `WebTarget` object by calling the `target` method providing the URL. To cause the HTTP request to occur first the `request` method on `WebTarget` and then the `get` method on the returned object need to be called. The `get` method call is a synchronous call that blocks until a response is received. This call returns a `Response` object, which can be interrogated to determine whether the request was successful:
 
 [source,java,indent=0,role="no_copy"]
 ----
@@ -150,14 +150,14 @@ The first thing to check is that a `200` response was received. The JUnit `asser
 include::finish/src/test/java/it/io/openliberty/guides/rest/EndpointTest.java[tags=response]
 ----
 
-Check the response body to ensure it returned the right information. Since the client and the server are running on the same machine, it is reasonable to expect that the system properties for the local and remote JVM would be the same. In this case, an assertion is made that the `os.name` system property for both JVM's is the same. You could write additional assertions to check for more values:
+Check the response body to ensure it returned the right information. Since the client and the server are running on the same machine, it is reasonable to expect that the system properties for the local and remote JVM would be the same. In this case, an assertion is made that the `os.name` system property for both JVMs is the same. You could write additional assertions to check for more values:
 
 [source,java,indent=0,role="no_copy"]
 ----
 include::finish/src/test/java/it/io/openliberty/guides/rest/EndpointTest.java[tags=body]
 ----
 
-To get the service running the Liberty server needs to be correctly configured.
+To get the service running, the Liberty server needs to be correctly configured.
 
 Replace the placeholder text with the following XML code to update the `src/main/liberty/config/server.xml` file:
 
@@ -165,10 +165,10 @@ Replace the placeholder text with the following XML code to update the `src/main
 ----
 include::finish/src/main/liberty/config/server.xml[]
 ----
-The configuration does the following:
+The configuration does the following actions:
 
 . Configures the server to support both JAX-RS 2.0 and JSON-P 1.0. This is specified in the `featureManager` element.
-. Configures the server to pick up the HTTP port numbers from variables which are then specified in the Maven `pom.xml` file. This is specified in the `httpEndpoint` element. Variables use the syntax `${variableName}`.
+. Configures the server to pick up the HTTP port numbers from variables, which are then specified in the Maven `pom.xml` file. This is specified in the `httpEndpoint` element. Variables use the syntax `${variableName}`.
 . Configures the server to run the produced Web application on a context root specified in the Maven `pom.xml` file. This is specified in the `webApplication` element.
 
 The variables being used in the `server.xml` file are provided by the `bootstrapProperties` section of the Maven `pom.xml`:


### PR DESCRIPTION
I edited some typos and stuff after running Acrolinx.

Could someone also please look at this sentence:
"The desired Content-Type for a JSON response is application/json, using MediaType.APPLICATION_JSON instead of the String literal is better because in the event of a spelling error a compile failure will occur."
It didn't make sense to me, so I changed it and may have also accidentally changed the meaning. If you could check it for accuracy, that'd be great! Thank you!