### PR TITLE
Revert "Add the guide release date"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,6 @@
 :projectid: rest-intro
 :page-layout: guide
 :page-duration: 30 minutes
-:page-date: 2017-09-19
 :page-description: Learn how to create a REST service with JAX-RS, JSON-P, and Open Liberty.
 :page-tags: ['REST', 'Getting Started']
 :page-permalink: /guides/{projectid}


### PR DESCRIPTION
Reverts OpenLiberty/guide-rest-intro#15

`page-date` is causing Jekyll build to break.  Another Asciidoctor attribute will be needed to replace `page-date`.  Until we have the new attribute, revert the introduction of `page-date`.