### PR TITLE
JDK9+ Support Review

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -66,13 +66,6 @@
             <version>1.0.7</version>
             <scope>test</scope>
         </dependency>
-        <!-- Support for JDK 9 and above -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -60,13 +60,6 @@
             <version>1.0.7</version>
             <scope>test</scope>
         </dependency>
-        <!-- Support for JDK 9 and above -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/guides-common/issues/459

End to end test successfully completed with `openjdk version "11.0.7"`
Successfully tested with `openjdk version "1.8.0_252"`