### PR TITLE
Support empty commit to trigger conversion

### DIFF
--- a/.github/workflows/triggerConversion.yml
+++ b/.github/workflows/triggerConversion.yml
@@ -1,4 +1,4 @@
-name: action
+name: Rebuild cloud-hosted guide
 
 # Controls when the action will run. Triggers the workflow on push
 # events but only for the master branch
@@ -7,11 +7,6 @@ on:
     branches:
       - 'master'
       - 'qa'
-    paths:
-      - 'README.adoc'
-      - 'start/**'
-      - 'finish/**'
-      - 'assets/**'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
- rename the action to Rebuild cloud-hosted guide
- support empty commit 