### PR TITLE
Update branch master -> main on trigger action

### DIFF
--- a/.github/workflows/triggerConversion.yml
+++ b/.github/workflows/triggerConversion.yml
@@ -28,4 +28,4 @@ jobs:
         repo: OpenLiberty/cloud-hosted-guides
         token: ${{ secrets.GUIDECONVERSIONTOOL_PASSWORD }}
         inputs: '{ "branch": "${{ github.ref }}", "guide_name": "${{ github.event.repository.name }}" }'
-        ref: "refs/heads/master"
+        ref: "refs/heads/main"


### PR DESCRIPTION
Trigger action is currently broken as default branch on `cloud-hosted-guides` has been changed from master to main.