### PR TITLE
Update branch name for cloud-hosted-guides trigger

### DIFF
--- a/.github/workflows/triggerConversion.yml
+++ b/.github/workflows/triggerConversion.yml
@@ -6,7 +6,10 @@ on:
   push:
     branches:
       - 'master'
+      - 'main'
+      - 'prod'
       - 'qa'
+      - 'staging'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -28,4 +31,4 @@ jobs:
         repo: OpenLiberty/cloud-hosted-guides
         token: ${{ secrets.GUIDECONVERSIONTOOL_PASSWORD }}
         inputs: '{ "branch": "${{ github.ref }}", "guide_name": "${{ github.event.repository.name }}" }'
-        ref: "refs/heads/main"
+        ref: "refs/heads/prod"


### PR DESCRIPTION
Changes branch `main` -> `prod`

Adds support for branches `prod`, `main`, and `staging`.